### PR TITLE
feat: `alloc` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,21 @@ members = [
 
 [features]
 default = []
-full = ["collections", "future", "metrics"]
+full = [
+  "alloc",
+  "profiler",
+  "collections",
+  "future",
+  "metrics",
+]
+alloc = ["dep:alloc"]
 collections = ["dep:collections"]
 future = ["dep:future"]
-metrics = ["dep:metrics", "future/metrics"]
+metrics = ["dep:metrics", "future/metrics", "alloc/metrics"]
+profiler = ["alloc/profiler"]
 
 [dependencies]
+alloc = { path = "./crates/alloc", optional = true }
 collections = { path = "./crates/collections", optional = true }
 future = { path = "./crates/future", optional = true }
 metrics = { path = "./crates/metrics", optional = true }
@@ -26,7 +35,15 @@ metrics = { path = "./crates/metrics", optional = true }
 [dev-dependencies]
 anyhow = "1"
 structopt = { version = "0.3", default-features = false }
-tokio = { version = "1.22", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
+
+[[example]]
+name = "alloc_profiler"
+required-features = ["alloc", "profiler"]
+
+[[example]]
+name = "alloc_stats"
+required-features = ["alloc", "metrics"]
 
 [[example]]
 name = "metrics"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Rust Utilities for WalletConnect
 
+## `alloc`
+
+Exports `Jemalloc` (from the [`tikv-jemallocator`](https://github.com/tikv/jemallocator)) with service metrics instrumentation. Also contains a custom lightweight version of the [DHAT profiler](https://github.com/WalletConnect/dhat-rs) to automate heap profiling in async environment.
+
 ## `collections`
 
 Extensions for collections such as `HashMap`.
@@ -16,7 +20,15 @@ Global service metrics. Currently based on `opentelemetry` SDK and exported in `
 
 ## Examples
 
-- [Metrics integration](examples/metrics.rs)
+- [Metrics integration](examples/metrics.rs). Prints service metrics in the default (`prometheus`) format.
+- [Allocation profiler](examples/alloc_profiler.rs). Demonstrates how to set up the DHAT profiler and record a profile of specified allocation bin sizes. Note that in order to get proper stack traces in a `release` build you need to enable debug symbols, e.g. using a custom build profile in `Cargo.toml`:
+  ```toml
+  [profile.release-debug]
+  inherits = "release"
+  lto = "thin"
+  debug = 1
+  ```
+- [Allocation stats](examples/alloc_stats.rs). Demonstrates how to set up Jemalloc and instrument allocation stats with service metrics.
 
 ## License
 

--- a/crates/alloc/Cargo.toml
+++ b/crates/alloc/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "alloc"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = []
+full = ["metrics", "profiler"]
+profiler = ["dep:dhat", "dep:tokio"]
+metrics = ["dep:metrics"]
+
+[dependencies]
+metrics = { path = "../metrics", optional = true }
+tikv-jemallocator = { version = "0.5", features = ["stats"] }
+tikv-jemalloc-ctl = { version = "0.5", features = ["use_std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+dhat = { git = "https://github.com/WalletConnect/dhat-rs.git", rev = "d16853d", optional = true }
+tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "time", "sync", "parking_lot", "macros"], optional = true }
+thiserror = { version = "1" }

--- a/crates/alloc/Cargo.toml
+++ b/crates/alloc/Cargo.toml
@@ -15,6 +15,6 @@ tikv-jemallocator = { version = "0.5", features = ["stats"] }
 tikv-jemalloc-ctl = { version = "0.5", features = ["use_std"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-dhat = { git = "https://github.com/WalletConnect/dhat-rs.git", rev = "d16853d", optional = true }
+dhat = { git = "https://github.com/WalletConnect/dhat-rs.git", rev = "78e1a05", optional = true }
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "time", "sync", "parking_lot", "macros"], optional = true }
 thiserror = { version = "1" }

--- a/crates/alloc/src/lib.rs
+++ b/crates/alloc/src/lib.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "profiler")]
+pub mod profiler;
+pub mod stats;
+
+pub use tikv_jemallocator::Jemalloc;

--- a/crates/alloc/src/profiler.rs
+++ b/crates/alloc/src/profiler.rs
@@ -1,0 +1,39 @@
+pub use dhat::*;
+use {std::time::Duration, tokio::sync::Mutex};
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[error("Profiler is already running")]
+pub struct AlreadyRunningError;
+
+static PROFILER_LOCK: Mutex<()> = Mutex::const_new(());
+
+/// Records a DHAT profile for the specified duration, and returns a
+/// JSON-serialized profile data.
+///
+/// Returns an error if a profile is already being recorded.
+pub async fn record(duration: Duration) -> Result<String, AlreadyRunningError> {
+    let _lock = PROFILER_LOCK.try_lock().map_err(|_| AlreadyRunningError)?;
+    let profiler = dhat::Profiler::new_heap();
+
+    // Let the profiler run for the specified duration.
+    tokio::time::sleep(duration).await;
+
+    Ok(profiler.finish())
+}
+
+#[cfg(test)]
+mod test {
+    use {super::record, std::time::Duration};
+
+    #[tokio::test]
+    async fn profiler_lock() {
+        let profile1 = tokio::spawn(record(Duration::from_millis(500)));
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let profile2 = record(Duration::from_millis(500)).await;
+        assert!(profile2.is_err());
+
+        let profile1_output = profile1.await.unwrap().unwrap();
+        assert!(!profile1_output.is_empty());
+    }
+}

--- a/crates/alloc/src/stats.rs
+++ b/crates/alloc/src/stats.rs
@@ -1,0 +1,145 @@
+use {
+    serde::Deserialize,
+    tikv_jemalloc_ctl::{epoch, stats_print},
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Jemalloc error: {0}")]
+    Jemalloc(#[from] tikv_jemalloc_ctl::Error),
+
+    #[error("Failed to write stats: {0}")]
+    Stats(std::io::Error),
+
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TotalStats {
+    pub allocated: u64,
+    pub active: u64,
+    pub metadata: u64,
+    pub resident: u64,
+    pub mapped: u64,
+    pub retained: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BinStats {
+    pub nmalloc: u64,
+    pub ndalloc: u64,
+    pub nrequests: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MergedArenaStats {
+    pub bins: Vec<BinStats>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ArenaStats {
+    pub merged: MergedArenaStats,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BinConstants {
+    pub size: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ArenaConstants {
+    pub bin: Vec<BinConstants>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct JemallocStats {
+    #[serde(rename = "stats")]
+    pub total: TotalStats,
+
+    #[serde(rename = "arenas")]
+    pub arena_constants: ArenaConstants,
+
+    #[serde(rename = "stats.arenas")]
+    pub arena_stats: ArenaStats,
+}
+
+#[derive(Debug, Deserialize)]
+struct GlobalStats {
+    jemalloc: JemallocStats,
+}
+
+pub fn collect_jemalloc_stats() -> Result<JemallocStats, Error> {
+    epoch::advance()?;
+
+    let mut opts = tikv_jemalloc_ctl::stats_print::Options::default();
+    opts.json_format = true;
+    opts.skip_per_arena = true;
+    opts.skip_mutex_statistics = true;
+
+    let mut buf = vec![];
+    stats_print::stats_print(&mut buf, opts).map_err(Error::Stats)?;
+
+    let global: GlobalStats = serde_json::from_slice(&buf[..])?;
+
+    Ok(global.jemalloc)
+}
+
+#[cfg(feature = "metrics")]
+pub fn update_jemalloc_metrics() -> Result<(), Error> {
+    use metrics::{gauge, otel};
+
+    let stats = collect_jemalloc_stats()?;
+    let total = &stats.total;
+
+    // Total number of bytes allocated by the application. This corresponds to
+    // `stats.allocated` in jemalloc's API.
+    gauge!("jemalloc_memory_allocated", total.allocated);
+
+    // Total number of bytes in active pages allocated by the application. This
+    // corresponds to `stats.active` in jemalloc's API.
+    gauge!("jemalloc_memory_active", total.active);
+
+    // Total number of bytes dedicated to `jemalloc` metadata. This corresponds to
+    // `stats.metadata` in jemalloc's API.
+    gauge!("jemalloc_memory_metadata", total.metadata);
+
+    // Total number of bytes in physically resident data pages mapped by the
+    // allocator. This corresponds to `stats.resident` in jemalloc's API.
+    gauge!("jemalloc_memory_resident", total.resident);
+
+    // Total number of bytes in active extents mapped by the allocator. This
+    // corresponds to `stats.mapped` in jemalloc's API.
+    gauge!("jemalloc_memory_mapped", total.mapped);
+
+    // Total number of bytes in virtual memory mappings that were retained rather
+    // than being returned to the operating system via e.g. `munmap(2)`. This
+    // corresponds to `stats.retained` in jemalloc's API.
+    gauge!("jemalloc_memory_retained", total.retained);
+
+    let bin_const = stats.arena_constants.bin.iter();
+    let bin_stats = stats.arena_stats.merged.bins.iter();
+
+    for (bin_const, bin_stats) in bin_const.zip(bin_stats) {
+        let tags = [otel::KeyValue::new(
+            "bin_size",
+            bin_const.size.try_into().unwrap_or(0i64),
+        )];
+
+        // Cumulative number of times a bin region of the corresponding size class was
+        // allocated from the arena, whether to fill the relevant tcache if opt.tcache
+        // is  enabled, or to directly satisfy an allocation request otherwise.
+        gauge!("jemalloc_memory_bin_nmalloc", bin_stats.nmalloc, &tags);
+
+        // Cumulative number of times a bin region of the corresponding size class was
+        // returned to the arena, whether to flush the relevant tcache if opt.tcache is
+        // enabled, or to directly deallocate an allocation otherwise.
+        gauge!("jemalloc_memory_bin_ndalloc", bin_stats.ndalloc, &tags);
+
+        // Cumulative number of allocation requests satisfied by bin regions of the
+        // corresponding size class.
+        gauge!("jemalloc_memory_bin_nrequests", bin_stats.nrequests, &tags);
+    }
+
+    Ok(())
+}

--- a/crates/future/Cargo.toml
+++ b/crates/future/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["full"]
+default = []
 full = ["metrics"]
 metrics = ["dep:metrics"]
 

--- a/crates/future/src/lib.rs
+++ b/crates/future/src/lib.rs
@@ -321,7 +321,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "metrics"))]
 mod test {
     use {
         super::*,

--- a/examples/alloc_profiler.rs
+++ b/examples/alloc_profiler.rs
@@ -1,0 +1,37 @@
+use {
+    std::time::Duration,
+    wc::alloc::{
+        profiler::{self, JemallocMultiBinFilter},
+        Jemalloc,
+    },
+};
+
+/// Configure profiler allocator to track specific allocation bins (4096 and
+/// 8192 bytes).
+#[global_allocator]
+static ALLOCATOR: profiler::Alloc<Jemalloc, JemallocMultiBinFilter<2>> =
+    profiler::Alloc::new(Jemalloc, JemallocMultiBinFilter::new([4096, 8192]));
+
+fn allocate(capacity: usize) -> Vec<u8> {
+    Vec::<u8>::with_capacity(capacity)
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let handle = tokio::spawn(profiler::record(Duration::from_millis(500)));
+
+    // Give some time for tokio to actually execute the profiler future.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Allocate memory.
+    let mut _buffer = allocate(256); // This one should not be recorded.
+    let mut _buffer = allocate(4096);
+    let mut _buffer = allocate(8192);
+
+    // Obtain JSON-serialized DHAT profile.
+    let profile = handle.await.unwrap().unwrap();
+
+    eprintln!("{profile}");
+
+    Ok(())
+}

--- a/examples/alloc_stats.rs
+++ b/examples/alloc_stats.rs
@@ -1,0 +1,16 @@
+use wc::metrics::ServiceMetrics;
+
+#[global_allocator]
+static ALLOCATOR: wc::alloc::Jemalloc = wc::alloc::Jemalloc;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    ServiceMetrics::init_with_name("metrics_example");
+
+    // Collect allocation stats from Jemalloc and update the metrics.
+    wc::alloc::stats::update_jemalloc_metrics().unwrap();
+
+    println!("{}", ServiceMetrics::export().unwrap());
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "alloc")]
+pub use alloc;
+
 #[cfg(feature = "collections")]
 pub use collections;
 #[cfg(feature = "future")]


### PR DESCRIPTION
# Description

This extracts and generalizes some heap stats and profiling code from the relay and makes it easier to consume by other other projects.

Related `dhat` PR: https://github.com/WalletConnect/dhat-rs/pull/1.

## How Has This Been Tested?

Some unit tests and new examples.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
