### PR TITLE
feat: http crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,21 @@ full = [
   "profiler",
   "collections",
   "future",
+  "http",
   "metrics",
 ]
 alloc = ["dep:alloc"]
 collections = ["dep:collections"]
 future = ["dep:future"]
-metrics = ["dep:metrics", "future/metrics", "alloc/metrics"]
+http = []
+metrics = ["dep:metrics", "future/metrics", "alloc/metrics", "http/metrics"]
 profiler = ["alloc/profiler"]
 
 [dependencies]
 alloc = { path = "./crates/alloc", optional = true }
 collections = { path = "./crates/collections", optional = true }
 future = { path = "./crates/future", optional = true }
+http = { path = "./crates/http", optional = true }
 metrics = { path = "./crates/metrics", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Extensions for collections such as `HashMap`.
 
 Convenience `Future` extensions.
 
+## `http`
+
+Metrics and other utils for HTTP servers.
+
 ## `metrics`
 
 Global service metrics. Currently based on `opentelemetry` SDK and exported in `prometheus` format.

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "http"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = []
+full = ["metrics"]
+metrics = ["dep:metrics", "dep:future"]
+
+[dependencies]
+future = { path = "../future", features = ["metrics"], optional = true }
+metrics = { path = "../metrics", optional = true }
+hyper = "0.14"
+tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "time", "macros"] }

--- a/crates/http/src/executor.rs
+++ b/crates/http/src/executor.rs
@@ -1,0 +1,62 @@
+use {
+    future::FutureExt,
+    metrics::TaskMetrics,
+    std::{future::Future, time::Duration},
+};
+
+/// Global `hyper` service task executor that uses the `tokio` runtime and adds
+/// metrics for the executed tasks.
+#[derive(Clone)]
+pub struct ServiceTaskExecutor {
+    timeout: Option<Duration>,
+    metrics_name: &'static str,
+}
+
+impl ServiceTaskExecutor {
+    pub fn new() -> Self {
+        Self {
+            timeout: None,
+            metrics_name: "",
+        }
+    }
+
+    /// Optional `task_name` metrics attribute.
+    pub fn name(self, metrics_name: Option<&'static str>) -> Self {
+        Self {
+            timeout: self.timeout,
+            metrics_name: metrics_name.unwrap_or(""),
+        }
+    }
+
+    /// Apply a timeout to all service tasks to prevent them from becoming
+    /// zombies for various reasons.
+    ///
+    /// Default is no timeout.
+    pub fn timeout(self, timeout: Option<Duration>) -> Self {
+        Self {
+            timeout,
+            metrics_name: self.metrics_name,
+        }
+    }
+}
+
+impl<F> hyper::rt::Executor<F> for ServiceTaskExecutor
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    fn execute(&self, fut: F) {
+        static METRICS: TaskMetrics = TaskMetrics::new("hyper_service_task");
+
+        let fut = fut.with_metrics(METRICS.with_name(self.metrics_name));
+        let timeout = self.timeout;
+
+        tokio::spawn(async move {
+            if let Some(timeout) = timeout {
+                let _ = fut.with_timeout(timeout).await;
+            } else {
+                fut.await;
+            }
+        });
+    }
+}

--- a/crates/http/src/executor.rs
+++ b/crates/http/src/executor.rs
@@ -6,7 +6,7 @@ use {
 
 /// Global `hyper` service task executor that uses the `tokio` runtime and adds
 /// metrics for the executed tasks.
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub struct ServiceTaskExecutor {
     timeout: Option<Duration>,
     metrics_name: &'static str,
@@ -14,10 +14,7 @@ pub struct ServiceTaskExecutor {
 
 impl ServiceTaskExecutor {
     pub fn new() -> Self {
-        Self {
-            timeout: None,
-            metrics_name: "",
-        }
+        Default::default()
     }
 
     /// Optional `task_name` metrics attribute.

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "metrics")]
+mod executor;
+
+#[cfg(feature = "metrics")]
+pub use executor::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,7 @@ pub use alloc;
 pub use collections;
 #[cfg(feature = "future")]
 pub use future;
+#[cfg(feature = "http")]
+pub use http;
 #[cfg(feature = "metrics")]
 pub use metrics;


### PR DESCRIPTION
# Description

Adds `http` crate with `ServiceTaskExecutor` extracted from the relay and made slightly more generic.

## How Has This Been Tested?

Manually with the relay integration: https://github.com/WalletConnect/rs-relay/pull/1073.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
