### PR TITLE
feat: custom attributes in otel task metrics

### DIFF
--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -9,3 +9,4 @@ prometheus = "0.13"
 opentelemetry = { version = "0.19", features = ["metrics", "rt-tokio"] }
 opentelemetry-prometheus = "0.12"
 once_cell = "1.17"
+smallvec = "1.11"

--- a/crates/metrics/src/task.rs
+++ b/crates/metrics/src/task.rs
@@ -85,7 +85,7 @@ impl OtelTaskMetricsRecorder {
     ) -> OtelTaskMetricsRecorder {
         Self {
             inner: self.inner.clone(),
-            name: self.name.clone(),
+            name: self.name,
             attributes: attributes.into_iter().collect(),
         }
     }


### PR DESCRIPTION
# Description

This adds custom attributes support to `OtelTaskMetricsRecorder`. Currently, the attributes are stored in a `SmallVec` with the size of `2`, since they're rather big (72 bytes). If we ever have a use case for more custom attributes, we should increase the capacity here, rather than rely on heap allocation.

## How Has This Been Tested?

Integration into the IRN.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
