### PR TITLE
fix: use debug formatting for analytics exprort error

### DIFF
--- a/crates/analytics/src/exporters/aws.rs
+++ b/crates/analytics/src/exporters/aws.rs
@@ -71,7 +71,7 @@ impl BatchExporter for AwsExporter {
             .body(ByteStream::from(data))
             .send()
             .await
-            .map_err(|err| AwsError::UploadError(err.to_string()))?;
+            .map_err(|err| AwsError::UploadError(format!("{err:?}")))?;
 
         info!("analytics successfully uploaded");
 


### PR DESCRIPTION
# Description

The current error in uninformative 

```json
{"timestamp":"2023-12-01T16:53:42.056975Z","level":"ERROR","fields":{"message":"analytics data export failed","error":"export error: error uploading to s3: service error","bug":true},"target":"analytics::collectors::batch"}
```

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
