### PR TITLE
fix(future): remove unnecessary trait bounds

### DIFF
--- a/crates/future/src/lib.rs
+++ b/crates/future/src/lib.rs
@@ -123,7 +123,7 @@ where
 /// Quality of life methods for cleaner futures spawning, timeout and
 /// cancellation using [`CancellationToken`].
 pub trait FutureExt {
-    type Future: Future + Send;
+    type Future: Future;
 
     /// Effectively wraps the future in [`tokio::time::timeout()`], returning a
     /// future that also allows you to run different future, in case the timeout

--- a/crates/future/src/lib.rs
+++ b/crates/future/src/lib.rs
@@ -270,8 +270,7 @@ pub trait StaticFutureExt {
 
 impl<T> FutureExt for T
 where
-    T: Future + Send,
-    T::Output: Send,
+    T: Future,
 {
     type Future = T;
 


### PR DESCRIPTION
# Description

Those bounds unnecessarily restrict `FutureExt`

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
