### PR TITLE
feat: `rate_limiting` token bucket sub module

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,16 @@ jobs:
             rust: stable
     env:
       RUST_BACKTRACE: full
+    services:
+      redis:
+        image: redis:7.2-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
     steps:
       - uses: actions/checkout@v3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ full = [
   "geoip",
   "http",
   "metrics",
+  "rate_limit",
 ]
 alloc = ["dep:alloc"]
 analytics = ["dep:analytics"]
@@ -33,6 +34,7 @@ geoip = ["dep:geoip"]
 http = []
 metrics = ["dep:metrics", "future/metrics", "alloc/metrics", "http/metrics"]
 profiler = ["alloc/profiler"]
+rate_limit = ["dep:rate_limit"]
 
 [workspace.dependencies]
 aws-sdk-s3 = "1.13"
@@ -45,6 +47,7 @@ future = { path = "./crates/future", optional = true }
 geoip = { path = "./crates/geoip", optional = true }
 http = { path = "./crates/http", optional = true }
 metrics = { path = "./crates/metrics", optional = true }
+rate_limit = { path = "./crates/rate_limit", optional = true }
 
 [dev-dependencies]
 anyhow = "1"

--- a/crates/rate_limit/Cargo.toml
+++ b/crates/rate_limit/Cargo.toml
@@ -14,5 +14,6 @@ thiserror = "1.0"
 tracing = "0.1"
 
 [dev-dependencies]
-anyhow = "1"
+futures = "0.3"
 tokio = { version = "1", features = ["full"] }
+uuid = "1.8"

--- a/crates/rate_limit/Cargo.toml
+++ b/crates/rate_limit/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 deadpool-redis = "0.12"
+moka = { version = "0.12", features = ["future"] }
 redis = { version = "0.23", default-features = false, features = ["script"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/rate_limit/Cargo.toml
+++ b/crates/rate_limit/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-deadpool-redis = "0.12"
+deadpool-redis = "0.14"
 moka = { version = "0.12", features = ["future"] }
-redis = { version = "0.23", default-features = false, features = ["script"] }
+redis = { version = "0.24", default-features = false, features = ["script"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/crates/rate_limit/Cargo.toml
+++ b/crates/rate_limit/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rate_limit"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+deadpool-redis = "0.12"
+redis = { version = "0.23", default-features = false, features = ["script"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+tracing = "0.1"
+
+[dev-dependencies]
+anyhow = "1"
+tokio = { version = "1", features = ["full"] }

--- a/crates/rate_limit/docker-compose.yml
+++ b/crates/rate_limit/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  redis:
+    image: redis:7.0
+    ports:
+      - "6379:6379"

--- a/crates/rate_limit/src/lib.rs
+++ b/crates/rate_limit/src/lib.rs
@@ -1,0 +1,160 @@
+use {
+    chrono::{DateTime, Duration, Utc},
+    core::fmt,
+    deadpool_redis::{Pool, PoolError},
+    redis::{RedisError, Script},
+    std::{collections::HashMap, sync::Arc},
+};
+
+pub type Clock = Option<Arc<dyn ClockImpl>>;
+pub trait ClockImpl: fmt::Debug + Send + Sync {
+    fn now(&self) -> DateTime<Utc>;
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Rate limit exceeded. Try again at {reset}")]
+pub struct RateLimitExceeded {
+    reset: u64,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InternalRateLimitError {
+    #[error("Redis pool error {0}")]
+    Pool(PoolError),
+
+    #[error("Redis error: {0}")]
+    Redis(RedisError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RateLimitError {
+    #[error(transparent)]
+    RateLimitExceeded(RateLimitExceeded),
+
+    #[error("Internal error: {0}")]
+    Internal(InternalRateLimitError),
+}
+
+pub async fn token_bucket(
+    redis_write_pool: &Arc<Pool>,
+    key: String,
+    max_tokens: u32,
+    interval: Duration,
+    refill_rate: u32,
+) -> Result<(), RateLimitError> {
+    let result = token_bucket_many(
+        redis_write_pool,
+        vec![key.clone()],
+        max_tokens,
+        interval,
+        refill_rate,
+    )
+    .await
+    .map_err(RateLimitError::Internal)?;
+
+    let (remaining, reset) = result.get(&key).expect("Should contain the key");
+    if remaining.is_negative() {
+        Err(RateLimitError::RateLimitExceeded(RateLimitExceeded {
+            reset: reset / 1000,
+        }))
+    } else {
+        Ok(())
+    }
+}
+
+pub async fn token_bucket_many(
+    redis_write_pool: &Arc<Pool>,
+    keys: Vec<String>,
+    max_tokens: u32,
+    interval: Duration,
+    refill_rate: u32,
+) -> Result<HashMap<String, (i64, u64)>, InternalRateLimitError> {
+    let now = Utc::now();
+
+    // Remaining is number of tokens remaining. -1 for rate limited.
+    // Reset is the time at which there will be 1 more token than before. This
+    // could, for example, be used to cache a 0 token count.
+    Script::new(include_str!("token_bucket.lua"))
+        .key(keys)
+        .arg(max_tokens)
+        .arg(interval.num_milliseconds())
+        .arg(refill_rate)
+        .arg(now.timestamp_millis())
+        .invoke_async::<_, String>(
+            &mut redis_write_pool
+                .clone()
+                .get()
+                .await
+                .map_err(InternalRateLimitError::Pool)?,
+        )
+        .await
+        .map_err(InternalRateLimitError::Redis)
+        .map(|value| serde_json::from_str(&value).expect("Redis script should return valid JSON"))
+}
+
+#[cfg(test)]
+mod tests {
+    const REDIS_URI: &str = "redis://localhost:6379";
+    use {
+        super::*,
+        deadpool_redis::{Config, Runtime},
+        redis::AsyncCommands,
+        tokio::time::sleep,
+    };
+
+    async fn redis_clear_keys(conn_uri: &str, keys: &[String]) {
+        let client = redis::Client::open(conn_uri).unwrap();
+        let mut conn = client.get_async_connection().await.unwrap();
+        for key in keys {
+            let _: () = conn.del(key).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_token_bucket() {
+        let cfg = Config::from_url(REDIS_URI);
+        let pool = Arc::new(cfg.create_pool(Some(Runtime::Tokio1)).unwrap());
+        let key = "test_token_bucket".to_string();
+
+        // Before running the test, ensure the test keys are cleared
+        redis_clear_keys(REDIS_URI, &[key.clone()]).await;
+
+        let max_tokens = 10;
+        let refill_interval = chrono::Duration::try_milliseconds(100).unwrap();
+        let refill_rate = 1;
+        let rate_limit = || async {
+            token_bucket_many(
+                &pool,
+                vec![key.clone()],
+                max_tokens,
+                refill_interval,
+                refill_rate,
+            )
+            .await
+            .unwrap()
+            .get(&key.clone())
+            .unwrap()
+            .to_owned()
+        };
+
+        // Iterate over the max tokens
+        for i in 0..=max_tokens {
+            let curr_iter = max_tokens as i64 - i as i64 - 1;
+            let result = rate_limit().await;
+            assert_eq!(result.0, curr_iter);
+        }
+
+        // Sleep for refill and try again
+        // Tokens numbers should be the same as the previous iteration
+        sleep((refill_interval * max_tokens as i32).to_std().unwrap()).await;
+
+        for i in 0..=max_tokens {
+            let curr_iter = max_tokens as i64 - i as i64 - 1;
+            let result = rate_limit().await;
+            assert_eq!(result.0, curr_iter);
+        }
+
+        // Clear keys after the test
+        redis_clear_keys(REDIS_URI, &[key.clone()]).await;
+    }
+}

--- a/crates/rate_limit/src/token_bucket.lua
+++ b/crates/rate_limit/src/token_bucket.lua
@@ -1,0 +1,44 @@
+-- Adapted from https://github.com/upstash/ratelimit/blob/3a8cfb00e827188734ac347965cb743a75fcb98a/src/single.ts#L311
+local keys = KEYS -- identifier including prefixes
+local maxTokens = tonumber(ARGV[1]) -- maximum number of tokens
+local interval = tonumber(ARGV[2]) -- size of the window in milliseconds
+local refillRate = tonumber(ARGV[3]) -- how many tokens are refilled after each interval
+local now = tonumber(ARGV[4]) -- current timestamp in milliseconds
+
+local results = {}
+
+for i, key in ipairs(keys) do
+    local bucket = redis.call("HMGET", key, "refilledAt", "tokens")
+
+    local refilledAt
+    local tokens
+
+    if bucket[1] == false then
+        refilledAt = now
+        tokens = maxTokens
+    else
+        refilledAt = tonumber(bucket[1])
+        tokens = tonumber(bucket[2])
+    end
+
+    if now >= refilledAt + interval then
+        local numRefills = math.floor((now - refilledAt) / interval)
+        tokens = math.min(maxTokens, tokens + numRefills * refillRate)
+
+        refilledAt = refilledAt + numRefills * interval
+    end
+
+    if tokens == 0 then
+        results[key] = {-1, refilledAt + interval}
+    else
+        local remaining = tokens - 1
+        local expireAt = math.ceil(((maxTokens - remaining) / refillRate)) * interval
+
+        redis.call("HSET", key, "refilledAt", refilledAt, "tokens", remaining)
+        redis.call("PEXPIRE", key, expireAt)
+        results[key] = {remaining, refilledAt + interval}
+    end
+end
+
+-- Redis doesn't support Lua table responses: https://stackoverflow.com/a/24302613
+return cjson.encode(results)

--- a/crates/rate_limit/src/token_bucket.lua
+++ b/crates/rate_limit/src/token_bucket.lua
@@ -6,24 +6,39 @@ local refillRate = tonumber(ARGV[3]) -- how many tokens are refilled after each 
 local now = tonumber(ARGV[4]) -- current timestamp in milliseconds
 
 local results = {}
-for i, key in ipairs(KEYS) do
-    local bucket = redis.call("HMGET", key, "refilledAt", "tokens")
-    local refilledAt = (bucket[1] == false and tonumber(now) or tonumber(bucket[1]))
-    local tokens = (bucket[1] == false and tonumber(maxTokens) or tonumber(bucket[2]))
 
-    if tonumber(now) >= refilledAt + interval then
-        tokens = math.min(tonumber(maxTokens), tokens + math.floor((tonumber(now) - refilledAt) / interval) * tonumber(refillRate))
-        refilledAt = refilledAt + math.floor((tonumber(now) - refilledAt) / interval) * interval
+for i, key in ipairs(keys) do
+    local bucket = redis.call("HMGET", key, "refilledAt", "tokens")
+
+    local refilledAt
+    local tokens
+
+    if bucket[1] == false then
+        refilledAt = now
+        tokens = maxTokens
+    else
+        refilledAt = tonumber(bucket[1])
+        tokens = tonumber(bucket[2])
     end
 
-    if tokens > 0 then
-        tokens = tokens - 1
-        redis.call("HSET", key, "refilledAt", refilledAt, "tokens", tokens)
-        redis.call("PEXPIRE", key, math.ceil(((tonumber(maxTokens) - tokens) / tonumber(refillRate)) * interval))
-        results[key] = {tokens, refilledAt + interval}
-    else
+    if now >= refilledAt + interval then
+        local numRefills = math.floor((now - refilledAt) / interval)
+        tokens = math.min(maxTokens, tokens + numRefills * refillRate)
+
+        refilledAt = refilledAt + numRefills * interval
+    end
+
+    if tokens == 0 then
         results[key] = {-1, refilledAt + interval}
+    else
+        local remaining = tokens - 1
+        local expireAt = math.ceil(((maxTokens - remaining) / refillRate)) * interval
+
+        redis.call("HSET", key, "refilledAt", refilledAt, "tokens", remaining)
+        redis.call("PEXPIRE", key, expireAt)
+        results[key] = {remaining, refilledAt + interval}
     end
 end
+
 -- Redis doesn't support Lua table responses: https://stackoverflow.com/a/24302613
 return cjson.encode(results)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,5 @@ pub use geoip;
 pub use http;
 #[cfg(feature = "metrics")]
 pub use metrics;
+#[cfg(feature = "rate_limit")]
+pub use rate_limit;


### PR DESCRIPTION
# Description

The rate-limiting token bucket mechanism (based on [#231](https://github.com/WalletConnect/notify-server/pull/231)) uses Redis and Moka in-memory cache.

The initial implementation was updated to use the local app cache in Moka and omit the Redis RTT calls (for single key calls) because we know the TTL when the token will be refilled in cases when the key is rate-limited. So we don't need to call the Redis until the TTL expires and we can use the local memory Moka cache. This should significantly eliminate Redis RTT calls in the case of DOS/flood. The initial Lua script was a bit optimized and minified.

## How Has This Been Tested?

* [New integration tests were introduced for the CI loop](https://github.com/WalletConnect/utils-rs/pull/14/files#diff-4bb737c17f7e69d6f041e206ed5a2e6ea8c936e0eb108088d3acb80956c001bbR116).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
