### PR TITLE
feat: upgrade otel

### DIFF
--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 [dependencies]
 pin-project = "1"
 prometheus = "0.13"
-opentelemetry = { version = "0.21.0", features = ["metrics"] }
-opentelemetry_sdk = { version = "0.21.2", features = ["metrics", "rt-tokio"] }
-opentelemetry-prometheus = "0.14"
+opentelemetry = { version = "0.22.0", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.22.1", features = ["metrics", "rt-tokio"] }
+opentelemetry-prometheus = "0.15"
 once_cell = "1.17"
 smallvec = "1.11"

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 pin-project = "1"
 prometheus = "0.13"
-opentelemetry = { version = "0.19", features = ["metrics", "rt-tokio"] }
-opentelemetry-prometheus = "0.12"
+opentelemetry = { version = "0.20.0", features = ["metrics"] }
+opentelemetry-prometheus = "0.13"
 once_cell = "1.17"
 smallvec = "1.11"

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 [dependencies]
 pin-project = "1"
 prometheus = "0.13"
-opentelemetry = { version = "0.20.0", features = ["metrics"] }
-opentelemetry-prometheus = "0.13"
+opentelemetry = { version = "0.21.0", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.21.2", features = ["metrics", "rt-tokio"] }
+opentelemetry-prometheus = "0.14"
 once_cell = "1.17"
 smallvec = "1.11"

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -1,9 +1,7 @@
 pub use {future::*, once_cell::sync::Lazy, opentelemetry as otel, task::*};
 use {
-    opentelemetry::{
-        metrics::{Meter, MeterProvider as _},
-        sdk::metrics::MeterProvider,
-    },
+    opentelemetry::metrics::{Meter, MeterProvider as _},
+    opentelemetry_sdk::metrics::MeterProvider,
     prometheus::{Error as PrometheusError, Registry, TextEncoder},
     std::{
         sync::{Arc, Mutex},

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -1,7 +1,7 @@
 pub use {future::*, once_cell::sync::Lazy, opentelemetry as otel, task::*};
 use {
-    opentelemetry::metrics::{Meter, MeterProvider as _},
-    opentelemetry_sdk::metrics::MeterProvider,
+    opentelemetry_sdk::metrics::SdkMeterProvider,
+    otel::metrics::{Meter, MeterProvider},
     prometheus::{Error as PrometheusError, Registry, TextEncoder},
     std::{
         sync::{Arc, Mutex},
@@ -25,7 +25,7 @@ static METRICS_CORE: Lazy<Arc<ServiceMetrics>> = Lazy::new(|| {
         .with_registry(registry.clone())
         .build()
         .unwrap();
-    let provider = MeterProvider::builder()
+    let provider = SdkMeterProvider::builder()
         .with_reader(prometheus_exporter)
         .build();
     let meter = provider.meter(service_name);

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -1,14 +1,10 @@
 pub use {future::*, once_cell::sync::Lazy, opentelemetry as otel, task::*};
 use {
     opentelemetry::{
-        metrics::{Meter, MeterProvider},
-        sdk::{
-            export::metrics::aggregation,
-            metrics::{processors, selectors},
-        },
+        metrics::{Meter, MeterProvider as _},
+        sdk::metrics::MeterProvider,
     },
-    opentelemetry_prometheus::PrometheusExporter,
-    prometheus::{Error as PrometheusError, TextEncoder},
+    prometheus::{Error as PrometheusError, Registry, TextEncoder},
     std::{
         sync::{Arc, Mutex},
         time::Duration,
@@ -26,26 +22,17 @@ static SERVICE_NAME: Mutex<Option<&str>> = Mutex::new(None);
 static METRICS_CORE: Lazy<Arc<ServiceMetrics>> = Lazy::new(|| {
     let service_name = SERVICE_NAME.lock().unwrap().unwrap_or(DEFAULT_SERVICE_NAME);
 
-    let controller = otel::sdk::metrics::controllers::basic(processors::factory(
-        selectors::simple::histogram(vec![]),
-        aggregation::cumulative_temporality_selector(),
-    ))
-    .with_resource(otel::sdk::Resource::new(vec![otel::KeyValue::new(
-        "service_name",
-        service_name,
-    )]))
-    .build();
+    let registry = Registry::new();
+    let prometheus_exporter = opentelemetry_prometheus::exporter()
+        .with_registry(registry.clone())
+        .build()
+        .unwrap();
+    let provider = MeterProvider::builder()
+        .with_reader(prometheus_exporter)
+        .build();
+    let meter = provider.meter(service_name);
 
-    let prometheus_exporter = opentelemetry_prometheus::exporter(controller).init();
-    let meter = prometheus_exporter
-        .meter_provider()
-        .unwrap()
-        .meter(service_name);
-
-    Arc::new(ServiceMetrics {
-        meter,
-        prometheus_exporter,
-    })
+    Arc::new(ServiceMetrics { registry, meter })
 });
 
 /// Global application metrics access.
@@ -53,8 +40,8 @@ static METRICS_CORE: Lazy<Arc<ServiceMetrics>> = Lazy::new(|| {
 /// The main functionality is to provide global access to opentelemetry's
 /// [`Meter`].
 pub struct ServiceMetrics {
+    registry: Registry,
     meter: Meter,
-    prometheus_exporter: PrometheusExporter,
 }
 
 impl ServiceMetrics {
@@ -81,7 +68,7 @@ impl ServiceMetrics {
 
     /// Generates export data in Prometheus format, serialized into string.
     pub fn export() -> Result<String, PrometheusError> {
-        let data = Self::get().prometheus_exporter.registry().gather();
+        let data = Self::get().registry.gather();
         TextEncoder::new().encode_to_string(&data)
     }
 

--- a/crates/metrics/src/macros.rs
+++ b/crates/metrics/src/macros.rs
@@ -19,7 +19,7 @@ macro_rules! gauge {
     }};
 
     ($name:expr, $value:expr, $tags:expr) => {{
-        $crate::gauge!($name).observe(&$crate::otel::Context::new(), $value as u64, $tags);
+        $crate::gauge!($name).observe($value as u64, $tags);
     }};
 }
 
@@ -39,7 +39,7 @@ macro_rules! histogram {
     }};
 
     ($name:expr, $value:expr, $tags:expr) => {{
-        $crate::histogram!($name).record(&$crate::otel::Context::new(), $value as f64, $tags);
+        $crate::histogram!($name).record($value as f64, $tags);
     }};
 }
 
@@ -59,6 +59,6 @@ macro_rules! counter {
     }};
 
     ($name:expr, $value:expr, $tags:expr) => {{
-        $crate::counter!($name).add(&$crate::otel::Context::new(), $value as u64, $tags);
+        $crate::counter!($name).add($value as u64, $tags);
     }};
 }

--- a/crates/metrics/src/task.rs
+++ b/crates/metrics/src/task.rs
@@ -99,9 +99,7 @@ impl OtelTaskMetricsRecorder {
 
 impl TaskMetricsRecorder for OtelTaskMetricsRecorder {
     fn record_task_started(&self) {
-        self.inner
-            .tasks_started
-            .add(&otel::Context::new(), 1, &self.combine_attributes());
+        self.inner.tasks_started.add(1, &self.combine_attributes());
     }
 
     fn record_task_finished(
@@ -117,18 +115,12 @@ impl TaskMetricsRecorder for OtelTaskMetricsRecorder {
         let mut attrs = self.combine_attributes();
         attrs.push(otel::KeyValue::new("completed", completed));
 
-        let ctx = otel::Context::new();
+        self.inner.total_duration.record(total_duration_ms, &attrs);
 
-        self.inner
-            .total_duration
-            .record(&ctx, total_duration_ms, &attrs);
+        self.inner.poll_duration.record(poll_duration_ms, &attrs);
 
-        self.inner
-            .poll_duration
-            .record(&ctx, poll_duration_ms, &attrs);
-
-        self.inner.poll_entries.add(&ctx, poll_entries, &attrs);
-        self.inner.tasks_finished.add(&ctx, 1, &attrs);
+        self.inner.poll_entries.add(poll_entries, &attrs);
+        self.inner.tasks_finished.add(1, &attrs);
     }
 }
 


### PR DESCRIPTION
# Description

Upgrade opentelemetry version to make histograms work properly by using [exponential histograms](https://opentelemetry.io/blog/2022/exponential-histograms/).

[Slack conversation](https://walletconnect.slack.com/archives/C068RRL89HC/p1713204696778319)

## Breaking changes

- `ctx` param removed from metric recording functions

## How Has This Been Tested?

The histogram feature not tested, will test in Notify Server in prod.

Usage in: https://github.com/WalletConnect/notify-server/pull/479

## Due Diligence

* [x] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
