### PR TITLE
fix: enable exponential histograms

### DIFF
--- a/crates/metrics/src/custom_aggregation_selector.rs
+++ b/crates/metrics/src/custom_aggregation_selector.rs
@@ -1,0 +1,29 @@
+use opentelemetry_sdk::metrics::{
+    reader::{AggregationSelector, DefaultAggregationSelector},
+    Aggregation, InstrumentKind,
+};
+
+#[derive(Clone, Default, Debug)]
+pub struct CustomAggregationSelector {
+    default_aggregation_selector: DefaultAggregationSelector,
+}
+
+impl CustomAggregationSelector {
+    /// Create a new default aggregation selector.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl AggregationSelector for CustomAggregationSelector {
+    fn aggregation(&self, kind: InstrumentKind) -> Aggregation {
+        match kind {
+            InstrumentKind::Histogram => Aggregation::Base2ExponentialHistogram {
+                max_size: 160,
+                max_scale: 20,
+                record_min_max: true,
+            },
+            x => self.default_aggregation_selector.aggregation(x),
+        }
+    }
+}

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -1,5 +1,5 @@
-pub use {future::*, once_cell::sync::Lazy, opentelemetry as otel, task::*};
 use {
+    custom_aggregation_selector::CustomAggregationSelector,
     opentelemetry_sdk::metrics::SdkMeterProvider,
     otel::metrics::{Meter, MeterProvider},
     prometheus::{Error as PrometheusError, Registry, TextEncoder},
@@ -8,7 +8,9 @@ use {
         time::Duration,
     },
 };
+pub use {future::*, once_cell::sync::Lazy, opentelemetry as otel, task::*};
 
+pub mod custom_aggregation_selector;
 pub mod future;
 pub mod macros;
 pub mod task;
@@ -22,6 +24,7 @@ static METRICS_CORE: Lazy<Arc<ServiceMetrics>> = Lazy::new(|| {
 
     let registry = Registry::new();
     let prometheus_exporter = opentelemetry_prometheus::exporter()
+        .with_aggregation_selector(CustomAggregationSelector::new())
         .with_registry(registry.clone())
         .build()
         .unwrap();


### PR DESCRIPTION
# Description

Make histogram bucket sizes calculated automatically. [Slack conversation](https://walletconnect.slack.com/archives/C068RRL89HC/p1713297037038809?thread_ts=1713204696.778319&cid=C068RRL89HC)

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
