### PR TITLE
Fix/simplify jemalloc metrics

### DIFF
--- a/crates/alloc/src/stats.rs
+++ b/crates/alloc/src/stats.rs
@@ -137,6 +137,11 @@ pub fn update_jemalloc_metrics() -> Result<(), Error> {
         // Cumulative number of allocation requests satisfied by bin regions of the
         // corresponding size class.
         gauge("jemalloc_memory_bin_nrequests", bin_stats.nrequests);
+
+        gauge(
+            "jemalloc_memory_bin_nactive",
+            bin_stats.nmalloc - bin_stats.ndalloc,
+        );
     }
 
     Ok(())

--- a/crates/alloc/src/stats.rs
+++ b/crates/alloc/src/stats.rs
@@ -138,10 +138,10 @@ pub fn update_jemalloc_metrics() -> Result<(), Error> {
         // corresponding size class.
         gauge("jemalloc_memory_bin_nrequests", bin_stats.nrequests);
 
-        gauge(
-            "jemalloc_memory_bin_nactive",
-            bin_stats.nmalloc - bin_stats.ndalloc,
-        );
+        let active = bin_stats.nmalloc - bin_stats.ndalloc;
+
+        gauge("jemalloc_memory_bin_nactive", active);
+        gauge("jemalloc_memory_bin_nactive_size", active * bin_const.size);
     }
 
     Ok(())


### PR DESCRIPTION
# Description

This adds two new metrics to jemalloc bin stats:

- `jemalloc_memory_bin_nactive`: the number of active allocations in the bin (`nmalloc - ndalloc`);
- `jemalloc_memory_bin_nactive_size`: the total size in bytes in active allocations in the bin (`(nmalloc - ndalloc) * bin_size`).

## How Has This Been Tested?

Manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
