### PR TITLE
fix: disable default-features of metrics-exporter-prometheus

### DIFF
--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -10,7 +10,7 @@ exporter_prometheus = ["metrics-exporter-prometheus"]
 
 [dependencies]
 metrics = "0.24"
-metrics-exporter-prometheus = { version = "0.17", optional = true }
+metrics-exporter-prometheus = { version = "0.17", default-features = false, optional = true }
 smallvec = "1"
 parking_lot = "0.12"
 enum-ordinalize = "4.3"


### PR DESCRIPTION
# Description

It brings unnecessary dependencies, we had `rustls` conflict because of that in `wcn`.

## How Has This Been Tested?

WCN

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
