### PR TITLE
fix: update prometheus exporter to 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ tokio = { version = "1", features = ["full"] }
 hyper = { version = "1.2.0", features = ["full"] }
 tower = { version = "0.4", features = ["util", "filter"] }
 axum = { workspace = true }
-metrics-exporter-prometheus = { version = "0.15", default-features = false }
+metrics-exporter-prometheus = { version = "0.18", default-features = false }
 
 [[example]]
 name = "alloc_profiler"

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -10,7 +10,7 @@ exporter_prometheus = ["metrics-exporter-prometheus"]
 
 [dependencies]
 metrics = "0.24"
-metrics-exporter-prometheus = { version = "0.17", default-features = false, optional = true }
+metrics-exporter-prometheus = { version = "0.18", default-features = false, optional = true }
 smallvec = "1"
 parking_lot = "0.12"
 enum-ordinalize = "4.3"
@@ -20,7 +20,7 @@ futures = "0.3"
 
 [dev-dependencies]
 wc_metrics = { path = "./" }
-metrics-exporter-prometheus = "0.17"
+metrics-exporter-prometheus = "0.18"
 prometheus-parse = "0.2"
 tikv-jemalloc-ctl = { version = "0.5", features = ["use_std"] }
 tikv-jemallocator = "0.5"


### PR DESCRIPTION
# Description

Updates `metrics-exporter-prometheus` to the latest version.

## How Has This Been Tested?

Relay integration.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
