### PR TITLE
ci: run CI on workflow changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,6 @@ on:
   workflow_dispatch:
   pull_request:
     paths-ignore:
-      - ".github/**"
       - "docs/**"
       - "README.md"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,11 +29,11 @@ jobs:
           - name: "Clippy"
             cmd: clippy
             args: --workspace --all-features --all-targets -- -D warnings
-            rust: nightly
+            rust: nightly-2026-02-11
           - name: "Formatting"
             cmd: fmt
             args: --all -- --check
-            rust: nightly
+            rust: nightly-2026-02-11
           - name: "Tests"
             cmd: nextest
             args: run --workspace --all-features --retries 3


### PR DESCRIPTION
Branch protection requires Clippy/Tests/Docs/Spellcheck/cocogitto, but `ci.yaml` had `paths-ignore: .github/**`, so a workflow-only PR (e.g. #35) can never get those checks reported and stays blocked.

- Drop `.github/**` from `paths-ignore`; workflow changes now run the pipeline they modify.